### PR TITLE
Add MiniMax H3 1K prompt dataset to the generative-AI app resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Full-stack platforms you can self-host or white-label. Leonardo AI charges $12�
 | [Seedance Watermark Remover](https://github.com/SamurAIGPT/seedance-2.0-watermark-remover) | Remove the Seedance 2.0 (AI生成) watermark from videos — no GPU required | Manual editing, paid removers | — |
 
 ---
+| [MiniMax H3 1K prompt dataset](https://neta.art/use-cases/en/h3-1000-prompt-list) | Curated 1K text-to-video prompts: 3-field structure anatomy, 10 reusable prompts, H3 vs. peer comparison | — | [H3 atlas](https://neta.art/use-cases/en/h3-1000-prompt-list) |
 
 ## 💄 Beauty & Fashion AI
 


### PR DESCRIPTION
Alongside the generative-AI apps collected here, this curated 1K text-to-video prompt dataset is a practical resource: 3-field prompt-structure anatomy, 10 hand-picked reusable prompts, and an H3 vs. peer model comparison.\n\nLinks:\n- Interactive atlas of all 1,000 H3 clips: https://neta.art/use-cases/en/h3-1000-prompt-list\n- Curated index repo: https://github.com/yangzhou-chaofan/minimax-h3-1000-prompts\n- Original dataset (ostris/minimax_h3_1k): https://huggingface.co/datasets/ostris/minimax_h3_1k