### PR TITLE
Add AIVideoAdherenceGate to Video Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Full-stack platforms you can self-host or white-label. Leonardo AI charges $12�
 | [AI VFX](https://github.com/SamurAIGPT/AI-VFX) | Add AI-powered visual effects to videos | Runway ($12–$76/mo), Kaiber ($5–$30/mo) | — |
 | [Open AI Video Editor](https://github.com/Anil-matcha/Open-AI-Video-Editor) | Cross-platform AI-native video editor with an agent-controlled timeline | Descript ($12/mo), Runway ($12/mo) | — |
 | [Seedance Watermark Remover](https://github.com/SamurAIGPT/seedance-2.0-watermark-remover) | Remove the Seedance 2.0 (AI生成) watermark from videos — no GPU required | Manual editing, paid removers | — |
+| [AIVideoAdherenceGate](https://github.com/madebysaira/AIVideoAdherenceGate) | Offline post-render semantic + motion health gate for AI video (motion, morph-drift, lip-sync) — run it on generated clips before delivery to catch static/morphed/desynced renders | Manual re-renders / no pre-delivery QA | — |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds [AIVideoAdherenceGate](https://github.com/madebysaira/AIVideoAdherenceGate) to the **🎬 Video Generation** table.

It is an offline-first, post-render semantic + motion health gate for AI-generated video that you run on generated clips before delivery:
- `motion_health` — detects STATIC / JITTER clips
- `morph_drift` — detects sudden identity/scene morph spikes
- `lipsync_health` — approximate audio↔mouth desync detection
- `technical` — ffprobe resolution/codec/fps/audio checks
- `vision_adherence` — optional OpenAI-compatible vision scoring

Pure Python 3 + ffmpeg, no required pip dependencies, 10 passing tests. Works with any AI video output (Kling, Veo, Runway, Seedance, Wan, HunyuanVideo, LTX, local ComfyUI). It is a cloneable OSS CLI (no hosted demo), matching the simpler-entry style used by other rows in this table.

## Test plan
- [x] Row follows the existing `| Template | Description | Competing With | Demo |` table format
- [x] Repo link returns HTTP 200
- [x] Added under Video Generation, before the section separator

Thanks!